### PR TITLE
Allow backwards compatibility when managing only one channel.

### DIFF
--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -61,7 +61,7 @@ class SendtochannelCommand extends AdminCommand
             $state = $session['state'];
         }
 
-        $channels = $this->getConfig('your_channel');
+        $channels = (array) $this->getConfig('your_channel');
 
         switch ($state) {
             default:


### PR DESCRIPTION
This allows the old config format when managing only one channel.
`$telegram->setCommandConfig('sendtochannel', ['your_channel' => '@my_only_channel']);`
