### PR TITLE
Small cleanup fixes

### DIFF
--- a/src/Commands/AdminCommands/SendtochannelCommand.php
+++ b/src/Commands/AdminCommands/SendtochannelCommand.php
@@ -215,18 +215,20 @@ class SendtochannelCommand extends AdminCommand
                 $this->conversation->notes['last_message_id'] = $message->getMessageId();
                 // no break
             case 5:
-                $this->conversation->stop();
                 $data['reply_markup'] = new ReplyKeyBoardHide(['selective' => true]);
 
                 if ($this->conversation->notes['post_message']) {
-                    $data['text'] = $this->publish(new Message($this->conversation->notes['message'], 'anystring'), $this->conversation->notes['channel'], $this->conversation->notes['caption']);
-                    $result = Request::sendMessage($data);
-                    break;
+                    $data['text'] = $this->publish(
+                        new Message($this->conversation->notes['message'], 'anystring'),
+                        $this->conversation->notes['channel'],
+                        $this->conversation->notes['caption']
+                    );
+                } else {
+                    $data['text'] = 'Abort by user, message not sent..';
                 }
 
-                $data['text'] = 'Abort by user, message not sent..';
+                $this->conversation->stop();
                 $result = Request::sendMessage($data);
-                break;
         }
         return $result;
     }

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -81,15 +81,26 @@ class Conversation
     }
 
     /**
+     * Clear all conversation variables.
+     *
+     * @return bool Always return true, to allow this method in an if statement.
+     */
+    protected function clear()
+    {
+        $this->conversation = null;
+        $this->protected_notes = null;
+        $this->notes = null;
+
+        return true;
+    }
+
+    /**
      * Load the conversation from the database
      *
      * @return bool
      */
     protected function load()
     {
-        $this->conversation = null;
-        $this->protected_notes = null;
-        $this->notes = null;
 
         //Select an active conversation
         $conversation = ConversationDB::selectConversation($this->user_id, $this->chat_id, 1);
@@ -102,7 +113,6 @@ class Conversation
 
             if ($this->command !== $this->conversation['command']) {
                 $this->cancel();
-                $this->conversation = null;
                 return false;
             }
 
@@ -153,7 +163,7 @@ class Conversation
      */
     public function stop()
     {
-        return $this->updateStatus('stopped');
+        return ($this->updateStatus('stopped') && $this->clear());
     }
 
     /**
@@ -163,7 +173,7 @@ class Conversation
      */
     public function cancel()
     {
-        return $this->updateStatus('cancelled');
+        return ($this->updateStatus('cancelled') && $this->clear());
     }
 
     /**

--- a/src/Conversation.php
+++ b/src/Conversation.php
@@ -61,13 +61,6 @@ class Conversation
     protected $command;
 
     /**
-     * Command has been provided
-     *
-     * @var string
-     */
-    protected $command_is_provided;
-
-    /**
      * Conversation contructor to initialize a new conversation
      *
      * @param int    $user_id
@@ -80,10 +73,8 @@ class Conversation
         $this->chat_id = $chat_id;
         $this->command = $command;
 
-        $this->command_is_provided = ($command !== null);
-
         //Try to load an existing conversation if possible
-        if (!$this->load() && $this->command_is_provided) {
+        if (!$this->load() && $command !== null) {
             //A new conversation start
             $this->start();
         }

--- a/src/ConversationDB.php
+++ b/src/ConversationDB.php
@@ -11,6 +11,7 @@
 namespace Longman\TelegramBot;
 
 use Longman\TelegramBot\DB;
+use Longman\TelegramBot\Exception\TelegramException;
 
 /**
  * Class ConversationDB
@@ -63,7 +64,7 @@ class ConversationDB extends DB
 
             $results = $sth->fetchAll(\PDO::FETCH_ASSOC);
 
-        } catch (PDOException $e) {
+        } catch (\Exception $e) {
             throw new TelegramException($e->getMessage());
         }
         return $results;
@@ -106,7 +107,7 @@ class ConversationDB extends DB
             $sth->bindParam(':date', $created_at);
 
             $status = $sth->execute();
-        } catch (PDOException $e) {
+        } catch (\Exception $e) {
             throw new TelegramException($e->getMessage());
         }
         return $status;
@@ -178,7 +179,7 @@ class ConversationDB extends DB
         try {
             $sth = self::$pdo->prepare($query);
             $status = $sth->execute($tokens);
-        } catch (PDOException $e) {
+        } catch (\Exception $e) {
             throw new TelegramException($e->getMessage());
         }
         return $status;


### PR DESCRIPTION
Remove some unused code.
Add `clear()` method to reset internal conversation variables.
Fix how `/sendtochannel` command is ended.
Fix exception handling for ConversationDB.
